### PR TITLE
DP: 2193

### DIFF
--- a/deulee/DP/2193.cpp
+++ b/deulee/DP/2193.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <cstring>
+
+int main(void) {
+	int N;
+	std::cin >> N;
+
+	// MOD로 나누는 것이 없는데 누적해서 경우의 수를 더해야 해서 overflow를 예방함
+	long long arr[91][2];
+	std::memset(arr, 0, sizeof(arr));
+
+	arr[1][1] = 1;
+	for (int i = 2; i <= N; i++) {
+		// 마지막 자릿수에 0이 들어올 수 있는 경우는 이전의 값이 0이거나 1이어야 함
+		// 마지막 자릿수에 1이 들어올 수 있는 경우는 이전의 값이 0이어야 함
+		arr[i][0] += arr[i - 1][0] + arr[i - 1][1];
+		arr[i][1] += arr[i - 1][0] ? arr[i - 1][0] : 0;
+	}
+	
+	printf("%lld\n", arr[N][0] + arr[N][1]);
+	return 0;
+}


### PR DESCRIPTION
# 개요
이쯤되면 사실상 모든 DP 문제는 현재의 값이 이전의 어떤 경우에 형성되는지를 파악하면 모든 DP를 해결할 수 있다고 본다.
- 물론 BottomUp일 경우 이긴 하지만 말이다.

그럼에도 위의 접근 방식을 머릿속에서 유지하고 있으면 문제를 쉽게 풀 수 있는 것 같다.

이번 문제에서는 문제를 자세히 보면 MOD로 나누는 것이 없는 것을 볼 수 있다. 누적되는 수에 MOD를 나눌 수가 없다면은 Overflow를 걱정해야 한다.
- 이것만 고려하면 똑같이 접근하면 된다.

# 문제 링크
[https://www.acmicpc.net/problem/2193](https://www.acmicpc.net/problem/2193)