### PR TITLE
김병대 32일차 (boj-20040)

### DIFF
--- a/김병대/32일차/boj-20040.cpp
+++ b/김병대/32일차/boj-20040.cpp
@@ -1,0 +1,52 @@
+// g++ .\main.cpp -o {실행파일명}
+#include <iostream>
+#include <algorithm>
+#include <climits>
+#include <string>
+#include <string.h>
+#include <set>
+#include <map>
+#include <math.h>
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>
+#include <tuple>
+
+typedef long long ll;
+using namespace std;
+
+int* T;
+
+// 자신의 Root를 찾는다
+int findRoot(int num) {
+    if(T[num] == num) return num;
+    return T[num] = findRoot(T[num]);
+}
+
+// 서로 Root를 합친다 (숫자가 낮은 경우 부모로 우대)
+void unionRoot(int a, int b) {
+    a = findRoot(a);
+    b = findRoot(b);
+    if(a < b) T[b] = a;
+    else T[a] = b;
+}
+
+int main() {
+    ios::sync_with_stdio(0);
+    cin.tie(NULL);
+
+    int n, m;
+    cin >> n >> m;
+    T = new int[n];
+    for(int i = 0; i < n; i++) T[i] = i;
+    for(int i = 1; i <= m; i++) {
+        int a, b;
+        cin >> a >> b;
+        int rootA = findRoot(a), rootB = findRoot(b);
+        if(rootA == rootB) { // root가 같은 것끼리 선분을 이으면 싸이클이 발생한다
+            cout << i;
+            return 0;
+        } else unionRoot(a, b);
+    }
+    cout << 0;
+}


### PR DESCRIPTION
# 개요
> ★★★★★
> Union-Find를 통한 Cycle 탐지 정석 문제
> 그래프의 싸이클을 완탐 돌리지 않고 어떻게 찾지? 라는 의문에 인터넷에 검색한 결과 Union-Find를 활용하는 방법이 있었음.
> 지금까지 무서워서 건드리지 않았던 알고리즘이지만 배워보기로 함.
> 생각보다는 구현이 간단하고 이해하는데 큰 노력을 들일 필요가 없었음.

# 문제 링크
https://www.acmicpc.net/problem/20040